### PR TITLE
Feat: (1)socket 초대 승낙/거절 추가 및 리팩토링 & (2)users.repository 함수 추가

### DIFF
--- a/src/repositories/users.ts
+++ b/src/repositories/users.ts
@@ -75,6 +75,67 @@ class UsersRepository {
     console.log(email, name, result);
     return result;
   };
+
+  // socket1(초대를 받은 경우 -> workspaceMember생성)
+  createWorkspaceMember = async (workspaceId: number, userId: number) => {
+    const createdWorkspaceMember = await prisma.workspacesMembers.create({
+      data: { WorkspaceId: workspaceId, UserId: userId },
+    });
+    return createdWorkspaceMember;
+  };
+
+  // socket2(유저찾기 - userId로만)
+  getUser = async (userId: number) => {
+    const user = await prisma.users.findUnique({
+      where: { userId },
+    });
+    return user;
+  };
+
+  // socket3(invitaions테이블 전체 조회)
+  getInvitations = async (userId: number) => {
+    const invitations = await prisma.invitations.findMany({
+      where: { InvitedByUserId: userId, accepted: null },
+    });
+    return invitations;
+  };
+
+  // socket4(invitaions테이블 만들기)
+  createInvitations = async (
+    workspaceId: number,
+    invitedUserId: number,
+    invitedByUserId: number,
+  ) => {
+    const createdInvitations = await prisma.invitations.create({
+      data: {
+        WorkspaceId: workspaceId,
+        InvitedUserId: invitedUserId, // 초대한 사람
+        InvitedByUserId: invitedByUserId, // 초대 받은 사람
+      },
+    });
+    return createdInvitations;
+  };
+
+  // socket5(invitations테이블 - accepted상태 업데이트하기)
+  updateAcceptanceInvitations = async (
+    invitationId: number,
+    accepted: boolean,
+  ) => {
+    const updatedInvitations = await prisma.invitations.update({
+      where: { invitationId },
+      data: { accepted },
+    });
+    return updatedInvitations;
+  };
+
+  // socket6(유저 lastLogin업데이트)
+  updateLastloginUser = async (loginUser: number, now: Date) => {
+    const updatedUser = await prisma.users.update({
+      where: { userId: loginUser },
+      data: { lastLogin: now },
+    });
+    return updatedUser;
+  };
 }
 
 export default UsersRepository;

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -2,6 +2,9 @@ import { Server as HttpServer } from 'http';
 import { Server as SocketServer } from 'socket.io';
 import { Application } from 'express';
 import prisma from './utils/prisma';
+import UsersRepository from './repositories/users';
+
+const usersRepository = new UsersRepository();
 
 const interval: number = 3000;
 
@@ -14,11 +17,10 @@ const WebSocket = (server: HttpServer, app: Application) => {
   });
   app.set('io', io);
   const board = io.of('/board');
-  const event = io.of('/main'); // '워크스페이스'초대용
+  const event = io.of('/main'); // for '워크스페이스'초대
 
   /** 1. board접속 및 컬럼 순서 변경 */
   board.on('connection', (socket) => {
-    // console.log(socket.request.headers);
     console.log('board접속:', socket.id);
     socket.on('disconnect', () => {
       console.log('board접속해제', socket.id);
@@ -51,36 +53,36 @@ const WebSocket = (server: HttpServer, app: Application) => {
   /** 2. event - 초대 */
   event.on('connection', (socket) => {
     console.log('event접속:', socket.id);
+    const loginUser = Number(socket.handshake.query.userId);
 
     socket.on('error', (error) => {
       console.error(error);
     });
 
+    // A. loginAndAlarm
     // main접속 -> (1)가장 최근 로그인 기록이 나오고 & (2)접속끊은 이후에 온 초대 메세지 확인
-    socket.on('loginAndAlarm', async (userId) => {
-      const user = await prisma.users.findUnique({
-        where: { userId },
-      });
+    socket.on('loginAndAlarm', async (data) => {
+      const userId = data.userId;
+      const user = await usersRepository.getUser(userId);
       const loginLog = user?.lastLogin || null;
-      const invitations: any = await prisma.invitations.findMany({
-        where: { InvitedByUserId: userId },
-      });
+
+      const invitations = await usersRepository.getInvitations(userId);
 
       let inviteResult: any = '';
-      // 1-초대목록이 없는 경우
-      if (!invitations) {
+      // 1)초대목록이 없는 경우
+      if (!invitations.length) {
         inviteResult = '초대받은 알람이 없습니다';
         socket.emit('loginAndAlarm', { loginLog, inviteResult });
       }
-      // 2-초대목록이 있다면
+      // 2)초대목록이 있다면
       else {
-        // 2-1: 접속한 적이 있으면
+        // 2-1)접속한 적이 있으면
         if (loginLog) {
           inviteResult = invitations.filter(
             (invitation: any) =>
               new Date(invitation.createdAt) > new Date(loginLog),
           );
-          // 2-2: 최초 접속(회원가입만 하고, 접속x경우 -> loginLog가 없음)
+          // 2-2)최초 접속(회원가입만 하고, 접속x경우 -> loginLog가 없음)
         } else {
           inviteResult = invitations;
         }
@@ -88,36 +90,53 @@ const WebSocket = (server: HttpServer, app: Application) => {
       }
     });
 
-    let loginUser: number = 0; // lastLogin업데이트 용 userId - 아래 disconnect에서 사용
+    // B. 초대 알람
     socket.on('invite', async (inviteInfo: any) => {
-      loginUser = inviteInfo.invitedByUserId;
+      const Invitation = await usersRepository.createInvitations(
+        inviteInfo.workspaceId,
+        inviteInfo.invitedUserId, // 초대한 사람
+        inviteInfo.invitedByUserId, // 초대 받은 사람
+      );
 
-      await prisma.invitations.create({
-        data: {
-          WorkspaceId: inviteInfo.WorkspaceId,
-          InvitedUserId: inviteInfo.InvitedUserId, // 초대한 사람
-          InvitedByUserId: inviteInfo.InvitedByUserId, // 초대 받은 사람
-        },
-      });
-
+      // *worksacpes.repositories만들어지면 DI로 리팩토링
       const workspace = await prisma.workspaces.findUnique({
-        where: { workspaceId: inviteInfo.WorkspaceId },
+        where: { workspaceId: inviteInfo.workspaceId },
       });
 
       const workspaceName = workspace?.workspaceName;
-      inviteInfo['WorkspaceName'] = workspaceName; // 객체에 name 추가
+      inviteInfo['workspaceName'] = workspaceName;
+      inviteInfo['invitationId'] = Invitation.invitationId;
 
-      io.to(socket.id).emit('invite', inviteInfo);
+      socket.emit('invite', inviteInfo);
     });
 
-    socket.on('disconnect', () => {
+    // C. 초대 승낙/거절 - user Router에서 마무리
+    socket.on('confirmInvitation', async (data) => {
+      if (data) {
+        await usersRepository.createWorkspaceMember(
+          data.workspaceId,
+          loginUser, // userId를 위에서 만든 loginUser로 대체
+        );
+        await usersRepository.updateAcceptanceInvitations(
+          data.invitationId,
+          data.accepted,
+        );
+        socket.emit('confirmInvitation', '초대를 승낙하였습니다');
+      } else {
+        await usersRepository.updateAcceptanceInvitations(
+          data.invitationId,
+          data.accepted,
+        );
+        socket.emit('confirmInvitation', '초대를 거절하였습니다');
+      }
+    });
+
+    socket.on('disconnect', async () => {
       console.log('event접속해제: ', socket.id);
-      console.log(loginUser); // 변경되는지 확인 - 안되면, socket.leave(userId) etc..(with join)
-      // 로그아웃 시간 저장
-      prisma.users.update({
-        where: { userId: loginUser },
-        data: { lastLogin: new Date() },
-      });
+      console.log(loginUser); // 체크용
+      // 로그아웃 시간 업데이트
+      const now = new Date();
+      await usersRepository.updateLastloginUser(loginUser, now);
       clearInterval(interval);
     });
   });


### PR DESCRIPTION
1. Socket관련
(1)초대 승낙/거절 코드를 추가하였습니다.
- '초대 알람'  통신을 주고 받을 때, 서버에서 invitationId를 추가로 보내도록 작업했습니다.
-  confirmInvitation을 프론트에서 하실 때, invitationId를 추가해서 보내주시면 감사하겠습니다 (api명세서도 업데이트 함)

(2)전반적으로 코드를 다듬었습니다
* a. '초대 알람' -> '초대 승낙/거절' 순으로 소켓 위치를 조절하였습니다. 
(기존엔 confirmInvitation -> 'invite'함수 순이었음)
* b. socket에서 직접 db를 수정하는 대신, users.repository의 함수들을 가져왔습니다

2. users.repository에 db를 수정하기 위한 소켓용 함수들을 작성하였습니다. (총6개)