### PR TITLE
Feat: socket 수정

### DIFF
--- a/src/controllers/columns.ts
+++ b/src/controllers/columns.ts
@@ -15,6 +15,12 @@ class ColumnsController {
     const boardId = +req.params.boardId;
     const { columnName } = req.body;
     const result = await this.columnsService.createColumn(boardId, columnName);
+
+    if (result) {
+      const io = req.app.get('io');
+      io.of('/board').emit('addColumn', result);
+    }
+
     res.status(200).send(result);
   });
 
@@ -35,7 +41,7 @@ class ColumnsController {
     // update될 때마다, 해당 방의 모든 사용자에게 정보 전송해서 업데이트(실시간으로)
     if (result) {
       const io = req.app.get('io');
-      io.of('/board').emit('updateColumnOrder', result);
+      io.of('/board').emit('updateColumn', result);
     }
 
     res.status(200).send(result);
@@ -51,6 +57,12 @@ class ColumnsController {
       workspaceId,
       columnId,
     );
+
+    if (result) {
+      const io = req.app.get('io');
+      io.of('/board').emit('deleteColumn', result);
+    }
+
     res.status(200).send(result);
   });
 }

--- a/src/repositories/users.ts
+++ b/src/repositories/users.ts
@@ -117,13 +117,23 @@ class UsersRepository {
   };
 
   // socket5(invitations테이블 - accepted상태 업데이트하기)
-  updateAcceptanceInvitations = async (
-    invitationId: number,
-    accepted: boolean,
-  ) => {
+  acceptInvitations = async (invitationId: number, accepted: boolean) => {
     const updatedInvitations = await prisma.invitations.update({
       where: { invitationId },
       data: { accepted },
+    });
+    return updatedInvitations;
+  };
+
+  // socket5-2(invitations테이블 - accepted: false, 인자는 3개)
+  declineInvitations = async (
+    invitationId: number,
+    accepted: boolean,
+    deletedAt: Date,
+  ) => {
+    const updatedInvitations = await prisma.invitations.update({
+      where: { invitationId },
+      data: { accepted, deletedAt },
     });
     return updatedInvitations;
   };

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -41,11 +41,25 @@ const WebSocket = (server: HttpServer, app: Application) => {
         message: `(타인)${socket.id}님이 ${boardId}번 board에 입장했습니다`,
       });
 
-      // 칼럼 순서 변경 - 실시간 공지 -> /controllers/columns.ts의 updated에서 처리
-      socket.on('columnToServer', async (data: any) => {
+      // 1-1.칼럼 추가
+      socket.on('addToServer', async (data: any) => {
         console.log(data);
-        socket.emit('columnToClient', '본인이 순서 변경');
-        socket.to(boardId).emit('columnToClient', '타인이 순서 변경');
+        socket.emit('addToClient', '본인이 추가'); // 체크용
+        socket.to(boardId).emit('addToClient', '타인이 추가'); // 체크용
+      });
+
+      // 1-2.칼럼 수정
+      socket.on('changeToServer', async (data: any) => {
+        console.log(data);
+        socket.emit('changeToClient', '본인이 순서 변경'); // 체크용
+        socket.to(boardId).emit('changeToClient', '타인이 순서 변경'); // 체크용
+      });
+
+      // 1-3.칼럼 삭제
+      socket.on('deleteToServer', async (data: any) => {
+        console.log(data);
+        socket.emit('deleteToClient', '본인이 삭제'); // 체크용
+        socket.to(boardId).emit('deleteToClient', '타인이 삭제'); // 체크용
       });
     });
   });
@@ -117,15 +131,17 @@ const WebSocket = (server: HttpServer, app: Application) => {
           data.workspaceId,
           loginUser, // userId를 위에서 만든 loginUser로 대체
         );
-        await usersRepository.updateAcceptanceInvitations(
+        await usersRepository.acceptInvitations(
           data.invitationId,
           data.accepted,
         );
         socket.emit('confirmInvitation', '초대를 승낙하였습니다');
       } else {
-        await usersRepository.updateAcceptanceInvitations(
+        const deletedAt = new Date(); // Soft delete
+        await usersRepository.declineInvitations(
           data.invitationId,
           data.accepted,
+          deletedAt,
         );
         socket.emit('confirmInvitation', '초대를 거절하였습니다');
       }


### PR DESCRIPTION
0. 초대 승낙/거절시, Invitations테이블의 accpetance상태를 업데이트 하는 함수를 2개로 분할하였습니다
(위치: repository.users.ts) (프론트에서 추가로 작업할 것은 없습니다)
* 승낙 -> '인자2개'
* 거절 -> '인자3개' (삭제되는 시간 추가 - deletedAt)
---

1. 함수를 추가하였습니다
- (1)Socket.ts의 45번째 줄부터 59번째 줄
  - 칼럼추가: socket.on('addToServer')
  - 컬럼삭제: socket.on('deleteToServer')
  * 컬럼수정은 함수명을 변경하였습니다. (아래 참조)
  * 여기에서 socket.emit들은 신경 안 쓰셔도 될것 같습니다(체크용입니다)

- (2)controllers/columns.ts에서
  - 칼럼추가: 함수명: 'addColumn'  <- io.of('/board').emit('addColumn', result);
  - 칼럼삭제: 함수명: 'deleteColumn'  <- io.of('/board').emit('deleteColumn', result);
  * 칼럼수정은 함수명을 변경하였습니다. (아래 참조)


---
2. 함수명을 변경하였습니다
(1)controllers/columns.ts의 update함수에서 io.emit: 'updateColumnOrder -> updateColumn'
-> 프론트 Board.tsx에 70, 80번째즈음에 있는 socket.on, socket.off안의 함수명 변경 부탁드립니다
(2)socket.ts의 칼럼수정(on메세지): ColumnToServer -> changeToServer
-> 프론트 Board.tsx에 200번째즈음에 있는 'ColumnToServer' 함수명 수정을 부탁드립니다
